### PR TITLE
Update colours.py

### DIFF
--- a/loki/core/colours.py
+++ b/loki/core/colours.py
@@ -1,12 +1,12 @@
 import sys
 
-colors = True # Output should be colored
-machine = sys.platform # Detecting the os of current system
-if machine.lower().startswith(('os', 'win', 'darwin', 'ios')):
-    colors = False # Colors shouldn't be displayed in mac & windows
-if not colors:
-    white = green = red = yellow = blue = end = back = info = que = bad = good = run = res = ''
-else:
+colors = True
+machine = sys.platform.lower()
+if machine.startswith(('os', 'win', 'darwin', 'ios')):
+    colors = False
+
+white = green = red = yellow = blue = end = back = info = que = bad = good = run = res = sarcastic = ''
+if colors:
     white = '\033[97m'
     green = '\033[92m'
     red = '\033[91m'


### PR DESCRIPTION
bug fix:
(venv) maxime@Macbooks-MacBook-14 loki % sudo python loki.py   /Users/maxime/loki/loki/loki.py:24: SyntaxWarning: invalid escape sequence '\_'
  print('''%s
Traceback (most recent call last):
  File "/Users/maxime/loki/loki/loki.py", line 3, in <module>
    from core.colours import green, end, bad, yellow, white, sarcastic
ImportError: cannot import name 'sarcastic' from 'core.colours' (/Users/maxime/loki/loki/core/colours.py) (venv) maxime@Macbooks-MacBook-14 loki % pip install core.colors

the modifications I made to colours.py fixes the bug above.