### PR TITLE
fix: update social_media.py to Selenium 4 API and add missing deps

### DIFF
--- a/loki/core/social_media.py
+++ b/loki/core/social_media.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python3
 from selenium import webdriver
 from selenium.webdriver.chrome.service import Service
+from selenium.webdriver.common.by import By
 from webdriver_manager.chrome import ChromeDriverManager
 from core.colours import *
 import time
@@ -15,16 +16,17 @@ def create_social_accounts(person_data):
         driver.get("https://www.facebook.com/r.php")
         time.sleep(2)  # Wait for page load
 
-        # Fill in form (example fields; adjust selectors as needed)
-        driver.find_element_by_name("firstname").send_keys(person_data['name'].split()[0])
-        driver.find_element_by_name("lastname").send_keys(person_data['name'].split()[-1])
-        driver.find_element_by_name("reg_email__").send_keys(person_data['email'])
-        driver.find_element_by_name("reg_passwd__").send_keys("SecurePass123!")
-        driver.find_element_by_name("birthday_day").send_keys(person_data['birthday'].split('/')[0])
-        driver.find_element_by_name("birthday_month").send_keys(person_data['birthday'].split('/')[1])
-        driver.find_element_by_name("birthday_year").send_keys(person_data['birthday'].split('/')[2])
-        driver.find_element_by_css_selector(f"input[value='{person_data['gender'].lower()[0]}']").click()
-        driver.find_element_by_name("websubmit").click()
+        # Fill in form fields using the Selenium 4 API (By.NAME instead of
+        # the deprecated find_element_by_name shorthand removed in Selenium 4)
+        driver.find_element(By.NAME, "firstname").send_keys(person_data['name'].split()[0])
+        driver.find_element(By.NAME, "lastname").send_keys(person_data['name'].split()[-1])
+        driver.find_element(By.NAME, "reg_email__").send_keys(person_data['email'])
+        driver.find_element(By.NAME, "reg_passwd__").send_keys("SecurePass123!")
+        driver.find_element(By.NAME, "birthday_day").send_keys(person_data['birthday'].split('/')[0])
+        driver.find_element(By.NAME, "birthday_month").send_keys(person_data['birthday'].split('/')[1])
+        driver.find_element(By.NAME, "birthday_year").send_keys(person_data['birthday'].split('/')[2])
+        driver.find_element(By.CSS_SELECTOR, f"input[value='{person_data['gender'].lower()[0]}']").click()
+        driver.find_element(By.NAME, "websubmit").click()
         
         time.sleep(5)  # Wait for submission
         print(f"{good} Facebook account created for {person_data['name']}")

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ gender_guesser==0.4.0
 numpy==1.23.4
 opencv_python==4.6.0.66
 requests==2.25.1
+selenium>=4.0.0
+webdriver-manager>=4.0.0


### PR DESCRIPTION
## What

- Update `loki/core/social_media.py` to use the Selenium 4 `find_element(By.*, ...)` API
- Add `selenium` and `webdriver-manager` to `requirements.txt` (they were missing)

## Why

Selenium 4 removed the legacy shorthand methods like `find_element_by_name()` and `find_element_by_css_selector()` that were deprecated in Selenium 3. Any user running `pip install -r requirements.txt` and then using the `-soc` / `--social-create` flag will encounter two errors:

1. **`ImportError`** – `selenium` and `webdriver-manager` are imported in `social_media.py` but not listed in `requirements.txt`
2. **`AttributeError: 'WebDriver' object has no attribute 'find_element_by_name'`** – Selenium 4 removed these legacy methods

## How

**`loki/core/social_media.py`:**
- Added `from selenium.webdriver.common.by import By`
- Replaced all `find_element_by_name(x)` → `find_element(By.NAME, x)`
- Replaced `find_element_by_css_selector(x)` → `find_element(By.CSS_SELECTOR, x)`

**`requirements.txt`:**
- Added `selenium>=4.0.0`
- Added `webdriver-manager>=4.0.0`

## Testing

- Verified the updated syntax against the [Selenium 4 migration guide](https://www.selenium.dev/documentation/webdriver/getting_started/upgrade_to_selenium_4/)
- All `find_element_by_*` patterns replaced with the current `find_element(By.*, ...)` API

## Checklist

- [x] Fixes AttributeError crash on Selenium 4
- [x] Fixes missing dependency declaration in requirements.txt
- [x] No logic changes — only API migration for forward compatibility
- [x] Consistent with Selenium 4 official migration guide